### PR TITLE
Aiohttp path params

### DIFF
--- a/README.md
+++ b/README.md
@@ -72,7 +72,7 @@ oapi = AioHTTPApistrap()
 routes = web.RouteTableDef()
 
 @routes.get("/{param_a}/{param_b}")
-def endpoint(param_a: str, param_b: int):  # Note that the request parameter is optional
+def endpoint(param_a: str, param_b: int = 5):  # Note that the request parameter is optional
     return web.Response(text="Lorem ipsum")
 ```
 

--- a/README.md
+++ b/README.md
@@ -61,6 +61,20 @@ web.run_app(app)
 Please note that this is very similar to how Apistrap works with Flask. All decorators that work with Flask routes work
 the same with AioHTTP web routes. Also, you still have to put the route decorators on top.
 
+We also make it possible to read route parameters using function parameters like you would with Flask:
+
+```python
+from aiohttp import web
+from apistrap.aiohttp import AioHTTPApistrap
+
+oapi = AioHTTPApistrap()
+routes = web.RouteTableDef()
+
+@routes.get("/{param_a}/{param_b}")
+def endpoint(param_a: str, param_b: int):  # Note that the request parameter is optional
+    return web.Response(text="Lorem ipsum")
+```
+
 ### Request Body Parsing
 
 ```python

--- a/apistrap/aiohttp.py
+++ b/apistrap/aiohttp.py
@@ -7,7 +7,7 @@ from copy import deepcopy
 from itertools import chain
 from os import path
 from pathlib import Path
-from typing import Any, Callable, Coroutine, Optional, Tuple, Type, List
+from typing import Any, Callable, Coroutine, List, Optional, Tuple, Type
 
 import jinja2
 from aiohttp import web
@@ -288,10 +288,10 @@ class AioHTTPApistrap(Apistrap):
         if parameter.annotation == inspect.Parameter.empty:
             return value
 
-        if parameter.annotation == str or parameter.annotation == 'str':
+        if parameter.annotation == str or parameter.annotation == "str":
             return value
 
-        if parameter.annotation == int or parameter.annotation == 'int':
+        if parameter.annotation == int or parameter.annotation == "int":
             return int(value)
 
         return value
@@ -307,20 +307,24 @@ class AioHTTPApistrap(Apistrap):
         signature = inspect.signature(route.handler)
 
         request_param: Optional[inspect.Parameter] = next(
-            filter(lambda p: issubclass(p.annotation, BaseRequest), signature.parameters.values()),
-            None
+            filter(lambda p: issubclass(p.annotation, BaseRequest), signature.parameters.values()), None
         )
 
-        if not request_param and "request" in signature.parameters.keys() \
-                and signature.parameters["request"].annotation == inspect.Signature.empty:
+        if (
+            not request_param
+            and "request" in signature.parameters.keys()
+            and signature.parameters["request"].annotation == inspect.Signature.empty
+        ):
             request_param = signature.parameters["request"]
 
         takes_aiohttp_request = request_param is not None
 
-        additional_params: [inspect.Parameter] = [*filter(
-            lambda p: not takes_aiohttp_request or signature.parameters[p] != request_param,
-            signature.parameters.keys()
-        )]
+        additional_params: [inspect.Parameter] = [
+            *filter(
+                lambda p: not takes_aiohttp_request or signature.parameters[p] != request_param,
+                signature.parameters.keys(),
+            )
+        ]
 
         if not takes_aiohttp_request or additional_params:
             handler = route.handler
@@ -368,7 +372,7 @@ class AioHTTPApistrap(Apistrap):
                 "in": "path",
                 "name": param_name,
                 "required": True,
-                "schema": {"type": self._parameter_annotation_to_openapi_type(annotation)}
+                "schema": {"type": self._parameter_annotation_to_openapi_type(annotation)},
             }
 
             if param_name in param_doc.keys():

--- a/apistrap/aiohttp.py
+++ b/apistrap/aiohttp.py
@@ -301,7 +301,7 @@ class AioHTTPApistrap(Apistrap):
             parameter.annotation == str,
             parameter.annotation == "str",
             parameter.annotation == int,
-            parameter.annotation == "int"
+            parameter.annotation == "int",
         ]
 
         if not any(criteria):

--- a/apistrap/aiohttp.py
+++ b/apistrap/aiohttp.py
@@ -256,6 +256,7 @@ class AioHTTPApistrap(Apistrap):
     _get_ui.apistrap_ignore = True
 
     async def _process_routes(self, *args, **kwargs) -> None:
+    """Process all non-ignored routes and their parameters"""
         self._extract_specs()
 
         for route in self.app.router.routes():
@@ -289,7 +290,7 @@ class AioHTTPApistrap(Apistrap):
             return value
 
         if parameter.annotation == str or parameter.annotation == "str":
-            return value
+            return str(value)
 
         if parameter.annotation == int or parameter.annotation == "int":
             return int(value)
@@ -311,7 +312,7 @@ class AioHTTPApistrap(Apistrap):
         )
 
         if (
-            not request_param
+            request_param is not None
             and "request" in signature.parameters.keys()
             and signature.parameters["request"].annotation == inspect.Signature.empty
         ):

--- a/apistrap/aiohttp.py
+++ b/apistrap/aiohttp.py
@@ -1,3 +1,4 @@
+import inspect
 import json
 import logging
 import mimetypes
@@ -6,7 +7,7 @@ from copy import deepcopy
 from itertools import chain
 from os import path
 from pathlib import Path
-from typing import Any, Callable, Coroutine, Optional, Tuple, Type
+from typing import Any, Callable, Coroutine, Optional, Tuple, Type, List
 
 import jinja2
 from aiohttp import web
@@ -203,11 +204,12 @@ class ErrorHandlerMiddleware:
 
 
 class AioHTTPApistrap(Apistrap):
+    SYNTHETIC_WRAPPER_ATTR = "aiohttp_apistrap_wrapped_function"
+
     def __init__(self):
         super().__init__()
         self.app: web.Application = None
         self.error_middleware = ErrorHandlerMiddleware(self)
-        self._specs_extracted = False
         self._jinja_env = jinja2.Environment(
             loader=jinja2.FileSystemLoader(path.join(path.dirname(__file__), "templates"))
         )
@@ -229,12 +231,13 @@ class AioHTTPApistrap(Apistrap):
                 for ui_url in (self.ui_url, self.ui_url + "/"):
                     app.router.add_route("get", ui_url, self._get_ui)
 
+        app.on_startup.append(self._process_routes)
+
     def _get_spec(self, request: Request):
         """
         Serves the OpenAPI specification
         """
 
-        self._extract_specs()
         return web.Response(text=json.dumps(self.to_openapi_dict()), content_type="application/json", status=200)
 
     _get_spec.apistrap_ignore = True
@@ -252,21 +255,24 @@ class AioHTTPApistrap(Apistrap):
 
     _get_ui.apistrap_ignore = True
 
+    async def _process_routes(self, *args, **kwargs) -> None:
+        self._extract_specs()
+
+        for route in self.app.router.routes():
+            if self._is_route_ignored(route.method, route.handler):
+                continue
+
+            self._process_route_parameters(route)
+
     def _extract_specs(self) -> None:
         """
         Extract the specification data from the bound AioHTTP app. If the data was already extracted, do not do
         anything.
         """
 
-        if self._specs_extracted:
-            return
-
         route: AbstractRoute
         for route in self.app.router.routes():
-            if getattr(route.handler, "apistrap_ignore", False):
-                continue
-
-            if route.method.lower() not in ["get", "post", "put", "delete", "patch"]:
+            if self._is_route_ignored(route.method, route.handler):
                 continue
 
             url = ""
@@ -278,7 +284,64 @@ class AioHTTPApistrap(Apistrap):
 
             self.spec.path(url, {route.method.lower(): self._extract_operation_spec(route)})
 
-        self._specs_extracted = True
+    def _parse_parameter_value(self, parameter: inspect.Parameter, value: str):
+        if parameter.annotation == inspect.Parameter.empty:
+            return value
+
+        if parameter.annotation == str or parameter.annotation == 'str':
+            return value
+
+        if parameter.annotation == int or parameter.annotation == 'int':
+            return int(value)
+
+        return value
+
+    def _process_route_parameters(self, route: AbstractRoute) -> None:
+        """
+        If necessary, wrap the route handler with a coroutine that accepts a AioHTTP request, extracts parameters to
+        satisfy the underlying handler and forwards them to the original handler.
+
+        :param route: the route whose handler should be wrapped
+        """
+
+        signature = inspect.signature(route.handler)
+
+        request_param: Optional[inspect.Parameter] = next(
+            filter(lambda p: issubclass(p.annotation, BaseRequest), signature.parameters.values()),
+            None
+        )
+
+        if not request_param and "request" in signature.parameters.keys() \
+                and signature.parameters["request"].annotation == inspect.Signature.empty:
+            request_param = signature.parameters["request"]
+
+        takes_aiohttp_request = request_param is not None
+
+        additional_params: [inspect.Parameter] = [*filter(
+            lambda p: not takes_aiohttp_request or signature.parameters[p] != request_param,
+            signature.parameters.keys()
+        )]
+
+        if not takes_aiohttp_request or additional_params:
+            handler = route.handler
+            accepted_path_params = set(self._get_route_parameter_names(route)).intersection(additional_params)
+
+            async def wrapped_handler(request: Request):
+                kwargs = {
+                    name: self._parse_parameter_value(signature.parameters[name], request.match_info[name])
+                    for name in accepted_path_params
+                }
+
+                if takes_aiohttp_request:
+                    kwargs[request_param.name] = request
+
+                bound_args: inspect.BoundArguments = signature.bind_partial(**kwargs)
+
+                return await handler(*bound_args.args, **bound_args.kwargs)
+
+            setattr(wrapped_handler, self.SYNTHETIC_WRAPPER_ATTR, handler)
+
+            route._handler = wrapped_handler  # HACK
 
     def _extract_operation_spec(self, route: AbstractRoute) -> dict:
         """
@@ -290,23 +353,29 @@ class AioHTTPApistrap(Apistrap):
 
         specs_dict = deepcopy(getattr(route.handler, "specs_dict", {"parameters": [], "responses": {}}))
         specs_dict["summary"] = route.handler.__doc__.strip() if route.handler.__doc__ else ""
-
-        if isinstance(route.resource, DynamicResource):
-            parameters = re.findall(r"{([a-zA-Z0-9]+[^}]*)}", route.resource.get_info()["formatter"])
-
-            for arg in parameters:
-                param_data = {
-                    "in": "path",
-                    "name": arg,
-                    "required": True,
-                    "schema": {"type": "string"},  # TODO support other types too
-                }
-
-                specs_dict["parameters"].append(param_data)
-
         specs_dict["operationId"] = snake_to_camel(route.handler.__name__)
 
+        handler = getattr(route.handler, self.SYNTHETIC_WRAPPER_ATTR, route.handler)
+        signature = inspect.signature(handler)
+
+        for param_name in self._get_route_parameter_names(route):
+            parameter = signature.parameters.get(param_name, None)
+            annotation = parameter.annotation if parameter else None
+
+            specs_dict["parameters"].append({
+                "in": "path",
+                "name": param_name,
+                "required": True,
+                "schema": {"type": self._parameter_annotation_to_openapi_type(annotation)}
+            })
+
         return specs_dict
+
+    def _get_route_parameter_names(self, route: AbstractRoute) -> List[str]:
+        if not isinstance(route.resource, DynamicResource):
+            return []
+
+        return re.findall(r"{([a-zA-Z0-9]+[^}]*)}", route.resource.get_info()["formatter"])
 
     def _is_bound(self) -> bool:
         return self.app is not None

--- a/apistrap/aiohttp.py
+++ b/apistrap/aiohttp.py
@@ -310,9 +310,11 @@ class AioHTTPApistrap(Apistrap):
 
         signature = inspect.signature(route.handler)
 
-        request_param: Optional[inspect.Parameter] = next(
-            filter(lambda p: issubclass(p.annotation, BaseRequest), signature.parameters.values()), None
-        )
+        request_params = filter(lambda p: issubclass(p.annotation, BaseRequest), signature.parameters.values())
+        request_param: Optional[inspect.Parameter] = next(request_params, None)
+
+        if next(request_params, None) is not None:
+            raise TypeError("The decorated view has more than one possible parameter for the AioHTTP request")
 
         if (
             request_param is None

--- a/apistrap/aiohttp.py
+++ b/apistrap/aiohttp.py
@@ -256,7 +256,10 @@ class AioHTTPApistrap(Apistrap):
     _get_ui.apistrap_ignore = True
 
     async def _process_routes(self, *args, **kwargs) -> None:
-    """Process all non-ignored routes and their parameters"""
+        """
+        Process all non-ignored routes and their parameters
+        """
+
         self._extract_specs()
 
         for route in self.app.router.routes():
@@ -312,7 +315,7 @@ class AioHTTPApistrap(Apistrap):
         )
 
         if (
-            request_param is not None
+            request_param is None
             and "request" in signature.parameters.keys()
             and signature.parameters["request"].annotation == inspect.Signature.empty
         ):

--- a/apistrap/aiohttp.py
+++ b/apistrap/aiohttp.py
@@ -325,7 +325,7 @@ class AioHTTPApistrap(Apistrap):
 
         takes_aiohttp_request = request_param is not None
 
-        additional_params: [inspect.Parameter] = [
+        additional_params: List[inspect.Parameter] = [
             *filter(
                 lambda p: not takes_aiohttp_request or signature.parameters[p] != request_param,
                 signature.parameters.keys(),

--- a/apistrap/extension.py
+++ b/apistrap/extension.py
@@ -1,4 +1,5 @@
 import abc
+import re
 from abc import ABCMeta
 from typing import Callable, Dict, List, Optional, Type, Union
 
@@ -151,6 +152,32 @@ class Apistrap(metaclass=ABCMeta):
 
     def _parameter_annotation_to_openapi_type(self, annotation):
         return self.PARAMETER_TYPE_MAP.get(annotation, "string")
+
+    def _summary_from_docblock(self, docblock: Optional[str]) -> str:
+        if docblock is None:
+            return ""
+
+        lines = [*map(lambda line: line.strip(), docblock.strip().splitlines())]
+
+        if "" in lines:
+            lines = lines[:lines.index("")]
+
+        return "\n".join(lines)
+
+    def _parameters_from_docblock(self, docblock: Optional[str]) -> Dict[str, str]:
+        if docblock is None:
+            return {}
+
+        lines = [*map(lambda line: line.strip(), docblock.strip().splitlines())]
+        result = {}
+
+        if "" in lines:
+            for line in lines[lines.index(""):]:
+                match = re.match(r"^:param\s+([^:]+):\s+(.+)", line)
+                if match is not None:
+                    result[match.group(1)] = match.group(2)
+
+        return result
 
     ############################
     # Configuration properties #

--- a/apistrap/extension.py
+++ b/apistrap/extension.py
@@ -160,7 +160,7 @@ class Apistrap(metaclass=ABCMeta):
         lines = [*map(lambda line: line.strip(), docblock.strip().splitlines())]
 
         if "" in lines:
-            lines = lines[:lines.index("")]
+            lines = lines[: lines.index("")]
 
         return "\n".join(lines)
 
@@ -172,7 +172,7 @@ class Apistrap(metaclass=ABCMeta):
         result = {}
 
         if "" in lines:
-            for line in lines[lines.index(""):]:
+            for line in lines[lines.index("") :]:
                 match = re.match(r"^:param\s+([^:]+):\s+(.+)", line)
                 if match is not None:
                     result[match.group(1)] = match.group(2)

--- a/apistrap/extension.py
+++ b/apistrap/extension.py
@@ -5,6 +5,7 @@ from typing import Callable, Dict, List, Optional, Type, Union
 
 from apispec import APISpec
 from apispec.utils import OpenAPIVersion
+from docstring_parser import parse as parse_doc
 from schematics import Model
 
 from apistrap.decorators import IgnoreDecorator, IgnoreParamsDecorator, SecurityDecorator, TagsDecorator
@@ -157,27 +158,15 @@ class Apistrap(metaclass=ABCMeta):
         if docblock is None:
             return ""
 
-        lines = [*map(lambda line: line.strip(), docblock.strip().splitlines())]
-
-        if "" in lines:
-            lines = lines[: lines.index("")]
-
-        return "\n".join(lines)
+        return parse_doc(docblock).short_description
 
     def _parameters_from_docblock(self, docblock: Optional[str]) -> Dict[str, str]:
         if docblock is None:
             return {}
 
-        lines = [*map(lambda line: line.strip(), docblock.strip().splitlines())]
-        result = {}
-
-        if "" in lines:
-            for line in lines[lines.index("") :]:
-                match = re.match(r"^:param\s+([^:]+):\s+(.+)", line)
-                if match is not None:
-                    result[match.group(1)] = match.group(2)
-
-        return result
+        return {
+            param.arg_name: param.description for param in parse_doc(docblock).params if param.description.strip() != ""
+        }
 
     ############################
     # Configuration properties #

--- a/apistrap/flask.py
+++ b/apistrap/flask.py
@@ -148,11 +148,12 @@ class FlaskApistrap(Apistrap):
         """
 
         specs_dict = deepcopy(getattr(handler, "specs_dict", {"parameters": [], "responses": {}}))
-        specs_dict["summary"] = handler.__doc__.strip() if handler.__doc__ else ""
+        specs_dict["summary"] = self._summary_from_docblock(handler.__doc__)
         specs_dict["operationId"] = snake_to_camel(handler.__name__)
 
         signature = inspect.signature(handler)
         ignored = getattr(handler, "_ignored_params", [])
+        param_doc = self._parameters_from_docblock(handler.__doc__)
 
         for arg in signature.parameters.values():
             if arg.name not in ignored:
@@ -162,6 +163,9 @@ class FlaskApistrap(Apistrap):
                     "required": True,
                     "schema": {"type": self._parameter_annotation_to_openapi_type(arg.annotation)},
                 }
+
+                if arg.name in param_doc.keys():
+                    param_data["description"] = param_doc[arg.name]
 
                 specs_dict["parameters"].append(param_data)
 

--- a/apistrap/schematics_converters.py
+++ b/apistrap/schematics_converters.py
@@ -2,8 +2,16 @@ from inspect import getmro
 from typing import Any, Dict, Generator, Optional, Type
 
 from schematics import Model
-from schematics.types.base import (BaseType, BooleanType, DecimalType, FloatType, IntType, LongType, NumberType,
-                                   StringType)
+from schematics.types.base import (
+    BaseType,
+    BooleanType,
+    DecimalType,
+    FloatType,
+    IntType,
+    LongType,
+    NumberType,
+    StringType,
+)
 from schematics.types.compound import DictType, ListType, ModelType
 
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -3,3 +3,6 @@ line-length = 120
 
 [tool.isort]
 line_length = 120
+use_parentheses = true
+multi_line_output = 3
+include_trailing_comma = true

--- a/setup.py
+++ b/setup.py
@@ -24,7 +24,7 @@ setup(name='apistrap',
       zip_safe=False,
       setup_requires=['pytest-runner'],
       tests_require=['pytest', 'pytest-mock', 'pytest-flask', 'pytest-aiohttp', 'flask', 'aiohttp', 'numpy'],
-      install_requires=['apispec==1.2', 'schematics', 'more_itertools', 'Werkzeug', 'jinja2'],
+      install_requires=['apispec==1.2', 'schematics', 'more_itertools', 'Werkzeug', 'jinja2', 'docstring_parser>=0.3'],
       extras_require={
           'flask': ['flask'],
           'aiohttp': ['aiohttp'],

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,4 +1,5 @@
 import pytest
+from aiohttp.web_app import Application
 from flask import Flask
 from pytest_mock import MockFixture
 
@@ -23,6 +24,16 @@ def flask_apistrap(app):
     apistrap = FlaskApistrap()
     apistrap.init_app(app)
     yield apistrap
+
+
+@pytest.fixture()
+def aiohttp_initialized_client(aiohttp_client):
+    async def func(app: Application):
+        app.freeze()
+        await app.startup()
+        return await aiohttp_client(app)
+
+    yield func
 
 
 @pytest.fixture()

--- a/tests/test_aiohttp_accepts_decorator.py
+++ b/tests/test_aiohttp_accepts_decorator.py
@@ -2,7 +2,7 @@ import json
 
 import pytest
 from aiohttp import web
-from aiohttp.web_request import BaseRequest
+from aiohttp.web_request import BaseRequest, Request
 from schematics import Model
 from schematics.types import IntType, StringType
 
@@ -19,7 +19,7 @@ def app_with_accepts(aiohttp_apistrap):
 
     @routes.post("/")
     @aiohttp_apistrap.accepts(RequestModel)
-    async def view(aiohttp_request, req: RequestModel):
+    async def view(aiohttp_request: Request, req: RequestModel):
         assert isinstance(aiohttp_request, BaseRequest)
         assert req.string_field == "foo"
         assert req.int_field == 42
@@ -32,8 +32,8 @@ def app_with_accepts(aiohttp_apistrap):
     yield app
 
 
-async def test_accepts(app_with_accepts, aiohttp_client):
-    client = await aiohttp_client(app_with_accepts)
+async def test_accepts(app_with_accepts, aiohttp_initialized_client):
+    client = await aiohttp_initialized_client(app_with_accepts)
     response = await client.post("/", headers={"content-type": "application/json"}, data=json.dumps({
         "string_field": "foo",
         "int_field": 42
@@ -42,7 +42,7 @@ async def test_accepts(app_with_accepts, aiohttp_client):
     assert response.status == 200
 
 
-async def test_invalid_json(app_with_accepts, aiohttp_client):
-    client = await aiohttp_client(app_with_accepts)
+async def test_invalid_json(app_with_accepts, aiohttp_initialized_client):
+    client = await aiohttp_initialized_client(app_with_accepts)
     response = await client.post("/", json="asdfasdf")
     assert response.status == 400

--- a/tests/test_aiohttp_apistrap_extension.py
+++ b/tests/test_aiohttp_apistrap_extension.py
@@ -29,7 +29,7 @@ async def test_aiohttp_getters():
     assert oapi.description == "Description"
 
 
-async def test_aiohttp_spec_url(aiohttp_client):
+async def test_aiohttp_spec_url(aiohttp_initialized_client):
     oapi = AioHTTPApistrap()
 
     oapi.spec_url = "/myspecurl.json"
@@ -38,7 +38,7 @@ async def test_aiohttp_spec_url(aiohttp_client):
     app = web.Application()
     oapi.init_app(app)
 
-    client = await aiohttp_client(app)
+    client = await aiohttp_initialized_client(app)
     response = await client.get("/myspecurl.json")
 
     assert response.status == 200
@@ -47,7 +47,7 @@ async def test_aiohttp_spec_url(aiohttp_client):
     assert "paths" in data
 
 
-async def test_aiohttp_spec_url_reset(aiohttp_client):
+async def test_aiohttp_spec_url_reset(aiohttp_initialized_client):
     oapi = AioHTTPApistrap()
 
     oapi.spec_url = None
@@ -59,7 +59,7 @@ async def test_aiohttp_spec_url_reset(aiohttp_client):
     app = web.Application()
     oapi.init_app(app)
 
-    client = await aiohttp_client(app)
+    client = await aiohttp_initialized_client(app)
     response = await client.get("/myspecurl.json")
 
     assert response.status == 200
@@ -76,7 +76,7 @@ async def test_aiohttp_spec_url_cannot_be_set_after_init():
         oapi.spec_url = "whatever"
 
 
-async def test_aiohttp_disable_spec_url(aiohttp_client):
+async def test_aiohttp_disable_spec_url(aiohttp_initialized_client):
     oapi = AioHTTPApistrap()
 
     oapi.spec_url = None
@@ -85,12 +85,12 @@ async def test_aiohttp_disable_spec_url(aiohttp_client):
     app = web.Application()
     oapi.init_app(app)
 
-    client = await aiohttp_client(app)
+    client = await aiohttp_initialized_client(app)
     response = await client.get("/spec.json")
     assert response.status == 404
 
 
-async def test_aiohttp_disable_ui(aiohttp_client):
+async def test_aiohttp_disable_ui(aiohttp_initialized_client):
     oapi = AioHTTPApistrap()
 
     oapi.ui_url = None
@@ -99,7 +99,7 @@ async def test_aiohttp_disable_ui(aiohttp_client):
     app = web.Application()
     oapi.init_app(app)
 
-    client = await aiohttp_client(app)
+    client = await aiohttp_initialized_client(app)
     response = await client.get("/apidocs/")
     assert response.status == 404
 
@@ -112,7 +112,7 @@ async def test_aiohttp_ui_url_cannot_be_set_after_init():
         oapi.ui_url = None
 
 
-async def test_aiohttp_set_ui_url(aiohttp_client):
+async def test_aiohttp_set_ui_url(aiohttp_initialized_client):
     oapi = AioHTTPApistrap()
 
     oapi.ui_url = "/docs/"
@@ -121,7 +121,7 @@ async def test_aiohttp_set_ui_url(aiohttp_client):
     app = web.Application()
     oapi.init_app(app)
 
-    client = await aiohttp_client(app)
+    client = await aiohttp_initialized_client(app)
     response = await client.get("/docs/")
     assert response.status == 200
     response = await client.get("/docs")

--- a/tests/test_aiohttp_descriptions.py
+++ b/tests/test_aiohttp_descriptions.py
@@ -4,13 +4,13 @@ from aiohttp import web
 from apistrap.aiohttp import AioHTTPApistrap
 
 
-async def test_aiohttp_title_in_spec_json(aiohttp_client):
+async def test_aiohttp_title_in_spec_json(aiohttp_initialized_client):
     oapi = AioHTTPApistrap()
     app = web.Application()
     oapi.init_app(app)
     oapi.title = "A title"
 
-    client = await aiohttp_client(app)
+    client = await aiohttp_initialized_client(app)
     response = await client.get("/spec.json")
     assert response.status == 200
 
@@ -18,13 +18,13 @@ async def test_aiohttp_title_in_spec_json(aiohttp_client):
     assert data["info"]["title"] == "A title"
 
 
-async def test_aiohttp_description_in_spec_json(aiohttp_client):
+async def test_aiohttp_description_in_spec_json(aiohttp_initialized_client):
     oapi = AioHTTPApistrap()
     app = web.Application()
     oapi.init_app(app)
     oapi.description = "A description"
 
-    client = await aiohttp_client(app)
+    client = await aiohttp_initialized_client(app)
     response = await client.get("/spec.json")
     assert response.status == 200
 

--- a/tests/test_aiohttp_docblocks.py
+++ b/tests/test_aiohttp_docblocks.py
@@ -1,6 +1,6 @@
-import pytest
 import json
 
+import pytest
 from aiohttp import web
 
 from apistrap.aiohttp import AioHTTPApistrap

--- a/tests/test_aiohttp_docblocks.py
+++ b/tests/test_aiohttp_docblocks.py
@@ -1,0 +1,59 @@
+import pytest
+import json
+
+from aiohttp import web
+
+from apistrap.aiohttp import AioHTTPApistrap
+
+
+@pytest.fixture(scope="function")
+def app_with_params_as_args():
+    oapi = AioHTTPApistrap()
+
+    app = web.Application()
+    routes = web.RouteTableDef()
+    oapi.init_app(app)
+
+    @routes.get('/{param_a}/{param_b}')
+    async def view(param_a: str, param_b: int):
+        """
+        A cool view handler.
+
+        :param param_a: Parameter A
+        :param param_b: Parameter B
+        """
+
+        return web.Response(content_type="application/json", text=json.dumps({
+            "a": param_a,
+            "b": param_b
+        }))
+
+    app.add_routes(routes)
+
+    yield app
+
+
+async def test_summary_from_docblock(app_with_params_as_args, aiohttp_initialized_client):
+    client = await aiohttp_initialized_client(app_with_params_as_args)
+    response = await client.get("/spec.json")
+
+    assert response.status == 200
+    data = await response.json()
+    path = data["paths"]["/{param_a}/{param_b}"]["get"]
+
+    assert path["summary"] == "A cool view handler."
+
+
+async def test_parameters_from_docblock(app_with_params_as_args, aiohttp_initialized_client):
+    client = await aiohttp_initialized_client(app_with_params_as_args)
+    response = await client.get("/spec.json")
+
+    assert response.status == 200
+    data = await response.json()
+    path = data["paths"]["/{param_a}/{param_b}"]["get"]
+
+    param_a = next(filter(lambda p: p["name"] == "param_a", path["parameters"]), None)
+    param_b = next(filter(lambda p: p["name"] == "param_b", path["parameters"]), None)
+
+    assert param_a["description"] == "Parameter A"
+    assert param_b["description"] == "Parameter B"

--- a/tests/test_aiohttp_error_handlers.py
+++ b/tests/test_aiohttp_error_handlers.py
@@ -39,24 +39,24 @@ def app_with_errors_in_production(aiohttp_apistrap, error_routes):
     yield app
 
 
-async def test_http_error_handler(app_with_errors, aiohttp_client):
-    client = await aiohttp_client(app_with_errors)
+async def test_http_error_handler(app_with_errors, aiohttp_initialized_client):
+    client = await aiohttp_initialized_client(app_with_errors)
     response = await client.get('/nonexistent_url')
     assert response.status == 404
     data = await response.json()
     assert 'debug_data' not in data
 
 
-async def test_http_error_handler_in_production(app_with_errors_in_production, aiohttp_client):
-    client = await aiohttp_client(app_with_errors_in_production)
+async def test_http_error_handler_in_production(app_with_errors_in_production, aiohttp_initialized_client):
+    client = await aiohttp_initialized_client(app_with_errors_in_production)
     response = await client.get('/nonexistent_url')
     assert response.status == 404
     data = await response.json()
     assert 'debug_data' not in data
 
 
-async def test_client_error_handler(app_with_errors, aiohttp_client):
-    client = await aiohttp_client(app_with_errors)
+async def test_client_error_handler(app_with_errors, aiohttp_initialized_client):
+    client = await aiohttp_initialized_client(app_with_errors)
     response = await client.get('/client_error')
     assert response.status == 400
     data = await response.json()
@@ -64,16 +64,16 @@ async def test_client_error_handler(app_with_errors, aiohttp_client):
     assert data['debug_data']['exception_type'] == 'ApiClientError'
 
 
-async def test_client_error_handler_in_production(app_with_errors_in_production, aiohttp_client):
-    client = await aiohttp_client(app_with_errors_in_production)
+async def test_client_error_handler_in_production(app_with_errors_in_production, aiohttp_initialized_client):
+    client = await aiohttp_initialized_client(app_with_errors_in_production)
     response = await client.get('/client_error')
     assert response.status == 400
     data = await response.json()
     assert 'debug_data' not in data
 
 
-async def test_server_error_handler(app_with_errors, aiohttp_client):
-    client = await aiohttp_client(app_with_errors)
+async def test_server_error_handler(app_with_errors, aiohttp_initialized_client):
+    client = await aiohttp_initialized_client(app_with_errors)
     response = await client.get('/server_error')
     assert response.status == 500
     data = await response.json()
@@ -81,16 +81,16 @@ async def test_server_error_handler(app_with_errors, aiohttp_client):
     assert data['debug_data']['exception_type'] == 'ApiServerError'
 
 
-async def test_server_error_handler_in_production(app_with_errors_in_production, aiohttp_client):
-    client = await aiohttp_client(app_with_errors_in_production)
+async def test_server_error_handler_in_production(app_with_errors_in_production, aiohttp_initialized_client):
+    client = await aiohttp_initialized_client(app_with_errors_in_production)
     response = await client.get('/server_error')
     assert response.status == 500
     data = await response.json()
     assert 'debug_data' not in data
 
 
-async def test_internal_server_error_handler(app_with_errors, aiohttp_client):
-    client = await aiohttp_client(app_with_errors)
+async def test_internal_server_error_handler(app_with_errors, aiohttp_initialized_client):
+    client = await aiohttp_initialized_client(app_with_errors)
     response = await client.get('/internal_error')
     assert response.status == 500
     data = await response.json()
@@ -99,8 +99,8 @@ async def test_internal_server_error_handler(app_with_errors, aiohttp_client):
     assert data['debug_data']['exception_type'] == 'RuntimeError'
 
 
-async def test_internal_server_error_handler_in_production(app_with_errors_in_production, aiohttp_client):
-    client = await aiohttp_client(app_with_errors_in_production)
+async def test_internal_server_error_handler_in_production(app_with_errors_in_production, aiohttp_initialized_client):
+    client = await aiohttp_initialized_client(app_with_errors_in_production)
     response = await client.get('/internal_error')
     assert response.status == 500
     data = await response.json()

--- a/tests/test_aiohttp_extract_specs.py
+++ b/tests/test_aiohttp_extract_specs.py
@@ -6,7 +6,7 @@ from aiohttp import web
 from apistrap.aiohttp import AioHTTPApistrap
 
 
-async def test_aiohttp_spec_url_repeated_call(aiohttp_client):
+async def test_aiohttp_spec_url_repeated_call(aiohttp_initialized_client):
     oapi = AioHTTPApistrap()
 
     app = web.Application()
@@ -21,7 +21,7 @@ async def test_aiohttp_spec_url_repeated_call(aiohttp_client):
 
     app.add_routes(routes)
 
-    client = await aiohttp_client(app)
+    client = await aiohttp_initialized_client(app)
     response = await client.get('/spec.json')
 
     assert response.status == 200
@@ -36,7 +36,7 @@ async def test_aiohttp_spec_url_repeated_call(aiohttp_client):
     assert new_data == data
 
 
-async def test_aiohttp_spec_url_weird_method(aiohttp_client):
+async def test_aiohttp_spec_url_weird_method(aiohttp_initialized_client):
     oapi = AioHTTPApistrap()
 
     app = web.Application()
@@ -52,7 +52,7 @@ async def test_aiohttp_spec_url_weird_method(aiohttp_client):
 
     app.add_routes(routes)
 
-    client = await aiohttp_client(app)
+    client = await aiohttp_initialized_client(app)
     response = await client.get('/spec.json')
 
     assert response.status == 200
@@ -62,7 +62,7 @@ async def test_aiohttp_spec_url_weird_method(aiohttp_client):
     assert 'options' not in data['paths']['/']
 
 
-async def test_aiohttp_spec_url_with_params(aiohttp_client):
+async def test_aiohttp_spec_url_with_params(aiohttp_initialized_client):
     oapi = AioHTTPApistrap()
 
     app = web.Application()
@@ -77,7 +77,7 @@ async def test_aiohttp_spec_url_with_params(aiohttp_client):
 
     app.add_routes(routes)
 
-    client = await aiohttp_client(app)
+    client = await aiohttp_initialized_client(app)
     response = await client.get('/spec.json')
 
     assert response.status == 200
@@ -86,7 +86,7 @@ async def test_aiohttp_spec_url_with_params(aiohttp_client):
     assert data['paths']['/{param}/']['get']['parameters'][0]['name'] == 'param'
 
 
-async def test_aiohttp_spec_url_ignore_endpoint(aiohttp_client):
+async def test_aiohttp_spec_url_ignore_endpoint(aiohttp_initialized_client):
     oapi = AioHTTPApistrap()
 
     app = web.Application()
@@ -102,7 +102,7 @@ async def test_aiohttp_spec_url_ignore_endpoint(aiohttp_client):
 
     app.add_routes(routes)
 
-    client = await aiohttp_client(app)
+    client = await aiohttp_initialized_client(app)
     response = await client.get('/spec.json')
 
     assert response.status == 200

--- a/tests/test_aiohttp_path_params.py
+++ b/tests/test_aiohttp_path_params.py
@@ -2,6 +2,7 @@ import json
 
 import pytest
 from aiohttp import web
+from aiohttp.web_request import Request
 
 from apistrap.aiohttp import AioHTTPApistrap
 
@@ -149,3 +150,24 @@ async def test_aiohttp_path_param_optional_invocation_default(aiohttp_initialize
     data = await response.json()
 
     assert data["param"] == "Default"
+
+
+async def test_aiohttp_path_param_multiple_request_parameters(aiohttp_initialized_client):
+    oapi = AioHTTPApistrap()
+
+    app = web.Application()
+    routes = web.RouteTableDef()
+    oapi.init_app(app)
+
+    with pytest.raises(TypeError):
+        @routes.get('/')
+        @routes.get('/{param}')
+        async def view(request_1: Request, request_2: Request, param: str = "Default"):
+            return web.Response(content_type="application/json", text=json.dumps({
+                "param": param,
+            }))
+
+        app.add_routes(routes)
+
+        client = await aiohttp_initialized_client(app)
+        await client.get("/spec.json")

--- a/tests/test_aiohttp_path_params.py
+++ b/tests/test_aiohttp_path_params.py
@@ -1,7 +1,7 @@
 import json
 
-from aiohttp import web
 import pytest
+from aiohttp import web
 
 from apistrap.aiohttp import AioHTTPApistrap
 

--- a/tests/test_aiohttp_path_params.py
+++ b/tests/test_aiohttp_path_params.py
@@ -1,0 +1,151 @@
+import json
+
+from aiohttp import web
+import pytest
+
+from apistrap.aiohttp import AioHTTPApistrap
+
+
+@pytest.fixture(scope="function")
+def app_without_request_param():
+    oapi = AioHTTPApistrap()
+
+    app = web.Application()
+    routes = web.RouteTableDef()
+    oapi.init_app(app)
+
+    @routes.get('/')
+    async def view():
+        return web.Response(content_type="application/json", text=json.dumps({
+            "status": "OK"
+        }))
+
+    app.add_routes(routes)
+
+    yield app
+
+
+async def test_aiohttp_spec_no_request_param_spec(app_without_request_param, aiohttp_initialized_client):
+    client = await aiohttp_initialized_client(app_without_request_param)
+    response = await client.get('/spec.json')
+
+    assert response.status == 200
+    data = await response.json()
+    assert 'paths' in data
+    assert '/' in data['paths']
+
+    response = await client.get('/spec.json')
+
+    assert response.status == 200
+    new_data = await response.json()
+    assert new_data == data
+
+
+async def test_aiohttp_spec_no_request_param_invocation(app_without_request_param, aiohttp_initialized_client):
+    client = await aiohttp_initialized_client(app_without_request_param)
+    response = await client.get('/')
+
+    assert response.status == 200
+    data = await response.json()
+
+    assert data == {"status": "OK"}
+
+
+@pytest.fixture(scope="function")
+def app_with_params_as_args():
+    oapi = AioHTTPApistrap()
+
+    app = web.Application()
+    routes = web.RouteTableDef()
+    oapi.init_app(app)
+
+    @routes.get('/{param_a}/{param_b}')
+    async def view(param_a: str, param_b: int):
+        return web.Response(content_type="application/json", text=json.dumps({
+            "a": param_a,
+            "b": param_b
+        }))
+
+    app.add_routes(routes)
+
+    yield app
+
+
+async def test_aiohttp_path_params_as_args_spec(aiohttp_initialized_client, app_with_params_as_args):
+    client = await aiohttp_initialized_client(app_with_params_as_args)
+    response = await client.get('/spec.json')
+
+    assert response.status == 200
+    data = await response.json()
+
+    parameters = data["paths"]["/{param_a}/{param_b}"]["get"]["parameters"]
+    assert len(parameters) == 2
+
+    param_a = next(filter(lambda p: p["name"] == "param_a", parameters), None)
+    param_b = next(filter(lambda p: p["name"] == "param_b", parameters), None)
+
+    assert param_a == {"in": "path", "name": "param_a", "required": True, "schema": {"type": "string"}}
+    assert param_b == {"in": "path", "name": "param_b", "required": True, "schema": {"type": "integer"}}
+
+
+async def test_aiohttp_path_params_as_args_arg_assignment(aiohttp_initialized_client, app_with_params_as_args):
+    client = await aiohttp_initialized_client(app_with_params_as_args)
+    response = await client.get("/a/42")
+
+    assert response.status == 200
+    data = await response.json()
+
+    assert data == {
+        "a": "a",
+        "b": 42
+    }
+
+
+@pytest.fixture(scope="function")
+def app_with_optional_parameter():
+    oapi = AioHTTPApistrap()
+
+    app = web.Application()
+    routes = web.RouteTableDef()
+    oapi.init_app(app)
+
+    @routes.get('/')
+    @routes.get('/{param}')
+    async def view(param: str = "Default"):
+        return web.Response(content_type="application/json", text=json.dumps({
+            "param": param,
+        }))
+
+    app.add_routes(routes)
+
+    yield app
+
+
+async def test_aiohttp_path_param_optional_spec(aiohttp_initialized_client, app_with_optional_parameter):
+    client = await aiohttp_initialized_client(app_with_optional_parameter)
+    response = await client.get("spec.json")
+
+    assert response.status == 200
+    data = await response.json()
+
+    assert len(data["paths"]) == 2
+
+
+async def test_aiohttp_path_param_optional_invocation(aiohttp_initialized_client, app_with_optional_parameter):
+    client = await aiohttp_initialized_client(app_with_optional_parameter)
+    response = await client.get("/value")
+
+    assert response.status == 200
+    data = await response.json()
+
+    assert data["param"] == "value"
+
+
+async def test_aiohttp_path_param_optional_invocation_default(aiohttp_initialized_client, app_with_optional_parameter):
+    client = await aiohttp_initialized_client(app_with_optional_parameter)
+    response = await client.get("/")
+
+    assert response.status == 200
+    data = await response.json()
+
+    assert data["param"] == "Default"

--- a/tests/test_aiohttp_responds_with_decorator.py
+++ b/tests/test_aiohttp_responds_with_decorator.py
@@ -112,6 +112,7 @@ def app_with_responds_with(aiohttp_apistrap, tmpdir):
                             last_modified=2018)
 
     app.add_routes(routes)
+    aiohttp_apistrap.use_default_error_handlers = False
     aiohttp_apistrap.init_app(app)
     yield app
 
@@ -135,8 +136,8 @@ def aiohttp_catch_exceptions(app: web.Application):
         yield holder
 
 
-async def test_accepts(app_with_responds_with, aiohttp_client):
-    client = await aiohttp_client(app_with_responds_with)
+async def test_accepts(app_with_responds_with, aiohttp_initialized_client):
+    client = await aiohttp_initialized_client(app_with_responds_with)
     response = await client.get('/')
 
     assert response.status == 200
@@ -145,8 +146,8 @@ async def test_accepts(app_with_responds_with, aiohttp_client):
     assert data['string_field'] == 'Hello World'
 
 
-async def test_error(app_with_responds_with, aiohttp_client):
-    client = await aiohttp_client(app_with_responds_with)
+async def test_error(app_with_responds_with, aiohttp_initialized_client):
+    client = await aiohttp_initialized_client(app_with_responds_with)
     response = await client.get('/error')
 
     assert response.status == 400
@@ -155,8 +156,8 @@ async def test_error(app_with_responds_with, aiohttp_client):
     assert data['error_message'] == 'Error'
 
 
-async def test_weird(app_with_responds_with, aiohttp_client):
-    client = await aiohttp_client(app_with_responds_with)
+async def test_weird(app_with_responds_with, aiohttp_initialized_client):
+    client = await aiohttp_initialized_client(app_with_responds_with)
 
     with aiohttp_catch_exceptions(app_with_responds_with) as holder:
         await client.get('/weird')
@@ -164,8 +165,8 @@ async def test_weird(app_with_responds_with, aiohttp_client):
         assert isinstance(holder.exc, UnexpectedResponseError)
 
 
-async def test_invalid(app_with_responds_with, aiohttp_client):
-    client = await aiohttp_client(app_with_responds_with)
+async def test_invalid(app_with_responds_with, aiohttp_initialized_client):
+    client = await aiohttp_initialized_client(app_with_responds_with)
 
     with aiohttp_catch_exceptions(app_with_responds_with) as holder:
         await client.get('/invalid')
@@ -174,14 +175,14 @@ async def test_invalid(app_with_responds_with, aiohttp_client):
 
 
 @pytest.mark.parametrize('endpoint', ['/file', '/file_by_path'])
-async def test_file_response(aiohttp_client, app_with_responds_with, endpoint):
-    client = await aiohttp_client(app_with_responds_with)
+async def test_file_response(aiohttp_initialized_client, app_with_responds_with, endpoint):
+    client = await aiohttp_initialized_client(app_with_responds_with)
     response = await client.get(endpoint)
     assert await response.read() == b'hello'
 
 
-async def test_file_response_error(app_with_responds_with, aiohttp_client):
-    client = await aiohttp_client(app_with_responds_with)
+async def test_file_response_error(app_with_responds_with, aiohttp_initialized_client):
+    client = await aiohttp_initialized_client(app_with_responds_with)
 
     with aiohttp_catch_exceptions(app_with_responds_with) as holder:
         await client.get('/file_without_name')
@@ -190,15 +191,15 @@ async def test_file_response_error(app_with_responds_with, aiohttp_client):
 
 
 @pytest.mark.parametrize('endpoint', ['/file_with_mimetype', '/file_with_mimetype_decorator'])
-async def test_file_response_mimetype(aiohttp_client, app_with_responds_with, endpoint):
-    client = await aiohttp_client(app_with_responds_with)
+async def test_file_response_mimetype(aiohttp_initialized_client, app_with_responds_with, endpoint):
+    client = await aiohttp_initialized_client(app_with_responds_with)
     response = await client.get(endpoint)
     assert await response.read() == b'<a href="www.hello.com"></a>'
     assert response.headers['Content-Type'] == 'text/html'
 
 
-async def test_file_response_timestamp(aiohttp_client, app_with_responds_with):
-    client = await aiohttp_client(app_with_responds_with)
+async def test_file_response_timestamp(aiohttp_initialized_client, app_with_responds_with):
+    client = await aiohttp_initialized_client(app_with_responds_with)
     response = await client.get('/file_timestamp')
     assert await response.read() == b'hello'
     assert response.headers['Last-Modified'] == '2018'

--- a/tests/test_flask_docblocks.py
+++ b/tests/test_flask_docblocks.py
@@ -1,0 +1,43 @@
+import pytest
+from flask import jsonify
+
+
+@pytest.fixture(scope="function")
+def app_with_params_as_args(app, flask_apistrap):
+    @app.route('/<param_a>/<param_b>', methods=["get"])
+    def view(param_a: str, param_b: int):
+        """
+        A cool view handler.
+
+        :param param_a: Parameter A
+        :param param_b: Parameter B
+        """
+
+        return jsonify({
+            "a": param_a,
+            "b": param_b
+        })
+
+    yield app
+
+
+def test_summary_from_docblock(app_with_params_as_args, client):
+    response = client.get("/spec.json")
+
+    assert response.status_code == 200
+    path = response.json["paths"]["/{param_a}/{param_b}"]["get"]
+
+    assert path["summary"] == "A cool view handler."
+
+
+def test_parameters_from_docblock(app_with_params_as_args, client):
+    response = client.get("/spec.json")
+
+    assert response.status_code == 200
+    path = response.json["paths"]["/{param_a}/{param_b}"]["get"]
+
+    param_a = next(filter(lambda p: p["name"] == "param_a", path["parameters"]), None)
+    param_b = next(filter(lambda p: p["name"] == "param_b", path["parameters"]), None)
+
+    assert param_a["description"] == "Parameter A"
+    assert param_b["description"] == "Parameter B"


### PR DESCRIPTION
- Support reading path parameters as view function arguments in AioHTTP
- Use :param directives in doc blocks to document parameters