### PR TITLE
Better handling of security schemes and enforcers

### DIFF
--- a/apistrap/decorators.py
+++ b/apistrap/decorators.py
@@ -1,9 +1,14 @@
+from __future__ import annotations
+
 from dataclasses import dataclass
-from typing import Optional, Sequence, Type, Union
+from typing import TYPE_CHECKING, Optional, Sequence, Type, Union
 
 from schematics import Model
 
 from apistrap.tags import TagData
+
+if TYPE_CHECKING:
+    from apistrap.extension import SecurityScheme
 
 
 class IgnoreDecorator:
@@ -77,3 +82,4 @@ class SecurityDecorator:
     """
 
     scopes: Sequence[str]
+    security_scheme: Optional[SecurityScheme] = None

--- a/apistrap/extension.py
+++ b/apistrap/extension.py
@@ -29,13 +29,13 @@ class SecurityScheme(metaclass=ABCMeta):
     Description of an authentication method.
     """
 
-    def __init__(self, name: str, enforcer: Callable[[List[str]], None]):
+    def __init__(self, name: str):
         """
         :param name: Name of the scheme (used as the name in the OpenAPI specification)
-        :param enforcer: A function that takes a list of scopes and raises an error if the user doesn't have them
+        :param enforcer: An object invoked by an extension that takes a list of scopes and raises an error if the user
+                         doesn't have them
         """
         self.name = name
-        self.enforcer = enforcer
 
     @abc.abstractmethod
     def to_openapi_dict(self):
@@ -83,11 +83,11 @@ class OAuthSecurity(SecurityScheme):
     A description of an OAuth security scheme with an arbitrary list of OAuth 2 flows
     """
 
-    def __init__(self, name: str, enforcer: Callable, *flows: OAuthFlowDefinition):
+    def __init__(self, name: str, *flows: OAuthFlowDefinition):
         """
         :param flows: A list of OAuth 2 flows allowed by the security scheme
         """
-        super().__init__(name, enforcer)
+        super().__init__(name)
         self.flows = flows
 
     def to_openapi_dict(self):
@@ -361,16 +361,6 @@ class Apistrap(metaclass=ABCMeta):
             self.spec.components.schema(name, schema)
 
         return f"#/components/schemas/{name}"
-
-    def add_security_scheme(self, scheme: SecurityScheme):
-        """
-        Add a security scheme to be used by the API.
-
-        :param scheme: a description of the security scheme
-        """
-
-        self.security_schemes.append(scheme)
-        self.spec.components.security_scheme(scheme.name, scheme.to_openapi_dict())
 
     def add_tag_data(self, tag: TagData) -> None:
         """

--- a/tests/test_security_enforcement.py
+++ b/tests/test_security_enforcement.py
@@ -1,4 +1,4 @@
-from typing import List
+from typing import Sequence
 
 import pytest
 from flask import jsonify
@@ -8,7 +8,7 @@ from apistrap.flask import FlaskApistrap
 from apistrap.schemas import ErrorResponse
 
 
-def enforcer(scopes: List[str]):
+def enforcer(scopes: Sequence[str]):
     user_scopes = ["read", "write"]
 
     if not all((scope in user_scopes) for scope in scopes):
@@ -25,14 +25,14 @@ def app_with_oauth(app):
     oapi.add_security_scheme(
         OAuthSecurity(
             "oauth",
-            enforcer,
             OAuthFlowDefinition(
                 "authorization_code",
                 {"read": "Read stuff", "write": "Write stuff", "frobnicate": "Frobnicate stuff"},
                 "/auth",
                 "/token",
             ),
-        )
+        ),
+        enforcer
     )
 
     oapi.add_error_handler(ForbiddenRequestError, 403, lambda _: ErrorResponse())
@@ -62,14 +62,14 @@ def app_with_oauth_and_unsecured_endpoint(app):
     oapi.add_security_scheme(
         OAuthSecurity(
             "oauth",
-            enforcer,
             OAuthFlowDefinition(
                 "authorization_code",
                 {"read": "Read stuff", "write": "Write stuff", "frobnicate": "Frobnicate stuff"},
                 "/auth",
                 "/token",
             ),
-        )
+        ),
+        enforcer
     )
 
     oapi.add_error_handler(ForbiddenRequestError, 403, lambda _: ErrorResponse())

--- a/tests/test_security_spec.py
+++ b/tests/test_security_spec.py
@@ -10,11 +10,11 @@ def app_with_oauth(app):
     oapi.add_security_scheme(
         OAuthSecurity(
             "oauth",
-            lambda scopes: None,
             OAuthFlowDefinition(
                 "authorization_code", {"read": "Read stuff", "write": "Write stuff"}, "/auth", "/token"
             ),
-        )
+        ),
+        lambda scopes: None
     )
 
     @app.route("/secured", methods=["GET"])
@@ -61,11 +61,11 @@ def app_with_oauth_non_string_scopes(app):
     oapi.add_security_scheme(
         OAuthSecurity(
             "oauth",
-            lambda scopes: None,
             OAuthFlowDefinition(
                 "authorization_code", {"read": "Read stuff", "write": "Write stuff"}, "/auth", "/token"
             ),
-        )
+        ),
+        lambda scopes: None
     )
 
     @app.route("/secured", methods=["GET"])


### PR DESCRIPTION
The main benefit here is that we can pass the `Request` object to AioHTTP security enforcers. Not being able to do that rendered them mostly unusable.